### PR TITLE
Disable XDebug by default

### DIFF
--- a/provisioning/roles/php/README.md
+++ b/provisioning/roles/php/README.md
@@ -11,7 +11,8 @@ PROJECT_ROOT: "/var/www"
 
 Variables:
 - use_php56 - should PHP 5.6 be installed, default is false
-- use_xdebug - should XDebug be installed and enabled, default is false
+- use_xdebug - should XDebug be installed, default is false
+- activate_xdebug - should XDebug be activated, default is false
 - use_php5_fpm - should php-fpm be installed and used, default is true
 
 Dependencies
@@ -27,7 +28,7 @@ Example Playbook
 - hosts: all
   sudo: yes
   roles:
-    - { role: php, use_php56: true, use_xdebug: true }
+    - { role: php, use_php56: true, use_xdebug: true, activate_xdebug: true }
 ```
 
 Author Information

--- a/provisioning/roles/php/defaults/main.yml
+++ b/provisioning/roles/php/defaults/main.yml
@@ -6,6 +6,8 @@ use_php56: false
 
 use_xdebug: false
 
+activate_xdebug: false
+
 use_php5_fpm: true
 
 php_fpm_www_additional:

--- a/provisioning/roles/php/tasks/main.yml
+++ b/provisioning/roles/php/tasks/main.yml
@@ -75,10 +75,10 @@
   ignore_errors: true
   when: ansible_os_family == "Debian" and use_xdebug == true
 
-- name: Enable XDebug
-  command: php5enmod xdebug
+- name: Disable XDebug
+  command: php5dismod xdebug
   ignore_errors: true
-  when: ansible_os_family == "Debian" and use_xdebug == true
+  when: ansible_os_family == "Debian" and use_xdebug == true and activate_xdebug == false
 
 - name: Install the php-fpm specific libraries (APT)
   apt: name={{ item }} state=present update_cache=yes

--- a/provisioning/vagrant.yml
+++ b/provisioning/vagrant.yml
@@ -6,7 +6,7 @@
   sudo: yes
   roles:
     - nodejs
-    - { role: php, use_php56: true, use_xdebug: true }
+    - { role: php, use_php56: true, use_xdebug: true, activate_xdebug: false }
     - { role: mysql, use_mysql56: true}
     - { role: composer, use_composer_no_dev: no, install_vendors: false }
 


### PR DESCRIPTION
XDebug is not frequently used when developing eZ Publish sites so this will disable it by default.

Since XDebug is by default _activated_, the task disables XDebug if the value of `activate_xdebug` variable is `false`.
