### PR TITLE
use mpm_event instead of prefork/itk/worker

### DIFF
--- a/provisioning/roles/php/tasks/main.yml
+++ b/provisioning/roles/php/tasks/main.yml
@@ -163,3 +163,18 @@
   notify: restart Apache
   when: ansible_os_family == "Debian" and use_php5_fpm == true
   tags: [php, php_fpm]
+
+- name: Disable non-used MPM in Apache (FPM related)
+  apache2_module: state=absent name={{ item }}
+  ignore_errors: True
+  with_items: apache_nonfpm_mpm
+  notify: restart Apache
+  when: ansible_os_family == "Debian" and use_php5_fpm == true
+  tags: [php, php_fpm]
+
+- name: Enable required MPM in Apache (FPM related)
+  apache2_module: state=present name={{ item }}
+  with_items: apache_fpm_mpm
+  notify: restart Apache
+  when: ansible_os_family == "Debian" and use_php5_fpm == true
+  tags: [php, php_fpm]

--- a/provisioning/roles/php/vars/main.yml
+++ b/provisioning/roles/php/vars/main.yml
@@ -27,3 +27,12 @@ php_nofpm_packages:
 
 php_fpm_packages:
   - php5-fpm
+  - apache2-mpm-event
+
+apache_fpm_mpm:
+  - mpm_event
+
+apache_nonfpm_mpm:
+  - mpm_worker
+  - mpm_prefork
+  - mpm_itk


### PR DESCRIPTION
- when PHP FPM is active, use mpm_event instead of prefork/itk/worker and disable the rest
