### PR TITLE
Varnish fix

### DIFF
--- a/provisioning/roles/varnish/tasks/main.yml
+++ b/provisioning/roles/varnish/tasks/main.yml
@@ -1,12 +1,22 @@
 ---
 # tasks file for varnish
 
-- name: Add Varnish apt key
-  apt_key: url=http://repo.varnish-cache.org/debian/GPG-key.txt state=present
+- name: Varnish version to use
+  set_fact:
+    varnish_version: '4.1'
+
+- name: Set the packagecloud repository name based on the version.
+  set_fact:
+    varnish_packagecloud_repo: "varnish{{ varnish_version|replace('.', '') }}"
+
+- name: Add packagecloud.io Varnish apt key
+  apt_key:
+    url: https://packagecloud.io/varnishcache/{{ varnish_packagecloud_repo }}/gpgkey
+    state: present
 
 - name: Add Varnish apt repository
   apt_repository:
-    repo: 'deb http://repo.varnish-cache.org/ubuntu {{ ansible_distribution_release }} varnish-4.0'
+    repo: 'deb https://packagecloud.io/varnishcache/{{ varnish_packagecloud_repo }}/ubuntu {{ ansible_distribution_release }} main'
     state: present
 
 - name: Install Varnish.

--- a/provisioning/roles/varnish/templates/varnish-defaults.j2
+++ b/provisioning/roles/varnish/templates/varnish-defaults.j2
@@ -37,7 +37,6 @@ RELOAD_VCL=1
 #DAEMON_OPTS="-a :6081 \
 #             -T localhost:6082 \
 #             -b localhost:8080 \
-#             -u varnish -g varnish \
 #             -s file,/var/lib/varnish/varnish_storage.bin,1G"
 
 
@@ -50,7 +49,6 @@ RELOAD_VCL=1
 #DAEMON_OPTS="-a :6081 \
 #             -T localhost:6082 \
 #             -f /etc/varnish/default.vcl \
-#             -u varnish -g varnish \
 #             -S /etc/varnish/secret \
 #             -s file,/var/lib/varnish/varnish_storage.bin,1G"
 
@@ -99,7 +97,6 @@ DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
              -p thread_pool_min=${VARNISH_MIN_THREADS} \
              -p thread_pool_max=${VARNISH_MAX_THREADS} \
              -p thread_pool_timeout=${VARNISH_THREAD_TIMEOUT} \
-             -u varnish -g varnish \
              -S ${VARNISH_SECRET_FILE} \
              -s ${VARNISH_STORAGE}"
 #


### PR DESCRIPTION
This pull request fixes two issues:

**1. Replace non-existing (EOL) Varnish package repository host with new packagecloud.io routes, upgrade to Varnish 4.1**

The official packages for Debian, Ubuntu, CentOS and Red Hat are now located in repositories at Packagecloud.io.
https://packagecloud.io/varnishcache/varnish41/install#manual-deb

Varnish version has been changed to 4.1 since the 4.0 relaeases are cosidered EOL (see more on http://varnish-cache.org/releases/)

**2. Remove invalid options for Varnish 4.1 from the default varnishd configuration**

In Varnish 4.1 the -u and -g options have been deprecated and no longer used causing the error after the upgrade.